### PR TITLE
update for container vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet build
 RUN dotnet publish --runtime alpine-x64 -c Release -o out --self-contained true /p:PublishTrimmed=true
 
 # build runtime image with DoD CA Certificates
-FROM cingulara/openrmf-base:1.04.00
+FROM cingulara/openrmf-base:1.08.02
 RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
 
 RUN mkdir /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.01
+VERSION ?= 1.08.02
 NAME ?= "openrmf-api-scoring"
 AUTHOR ?= "Dale Bingham"
 PORT_EXT ?= 8082

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.00
+VERSION ?= 1.08.01
 NAME ?= "openrmf-api-scoring"
 AUTHOR ?= "Dale Bingham"
 PORT_EXT ?= 8082

--- a/src/openrmf-api-scoring.csproj
+++ b/src/openrmf-api-scoring.csproj
@@ -23,11 +23,17 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="mongodb.driver" Version="2.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.7.13" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="5.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.5.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/openrmf-api-scoring.csproj
+++ b/src/openrmf-api-scoring.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{4ac57005-52ed-4a80-8f81-5e860441d9ce}</ProjectGuid>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <Version>1.08.00</Version>
+    <Version>1.08.01</Version>
     <InformationalVersion>This is the OpenRMF Tool Scoring API from Cingulara</InformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Commits on Aug 28, 2022
[update for latest base image](https://github.com/Cingulara/openrmf-api-scoring/commit/5ac72a6e0308251df69e8465f0b9fab094af8ad4)

Commits on Nov 27, 2022
[updating vulnerability information for v1.8.3](https://github.com/Cingulara/openrmf-api-scoring/commit/a805f0078e63f5c0039582358461c7f1bfef3f86)